### PR TITLE
fix: contributing nav link points to CONTRIBUTING.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@
   <a href="https://docs.runqy.com"><strong>Documentation</strong></a> · 
   <a href="https://runqy.com"><strong>Website</strong></a> · 
   <a href="#examples">Examples</a> · 
-  <a href="#contributing">Contributing</a>
+  <a href="CONTRIBUTING.md">Contributing</a>
 </p>
 
 ---


### PR DESCRIPTION
The nav link used `#contributing` anchor which doesn't exist as a section. Fixed to point directly to `CONTRIBUTING.md`.